### PR TITLE
Fix: Wrong name for coolors in Online Design Tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -296,7 +296,7 @@ All kinds of online tools for design, from photo editors to wireframing, color g
 | [Infogram](https://infogram.com/)| Create infograms |
 | [ChartGo](https://www.chartgo.com/)| Create charts and graphs online |
 | [Cartoon Photo](https://cartoon.pho.to/)| Turn photos into cartoons |
-| [Colors](https://coolors.co/)| Color schemes generator |
+| [Coolors](https://coolors.co/)| Color schemes generator |
 | [ColorSpace](https://mycolor.space/)| Generate nice color palettes from one color |
 | [Adobe Color](https://color.adobe.com/create)| Create color palettes, extract gradients from images, etc. |
 | [Logo Maker](https://logomakr.com/)| Create custom logos |


### PR DESCRIPTION
The brand name for `coolors.co` is _Coolors_ instead of _Colors_