### PR TITLE
added one colour link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,9 +115,7 @@
 | [Gradient Hunt](https://gradienthunt.com/)| A free and open platform for gradient inspiration with thousands of trendy hand-picked color gradients |
 | [Web Gradients](https://webgradients.com/)| A free website to find good css gradients |
 | [ColorBox](https://www.colorbox.io)| A free website to produce color set  |
-| [gradienta](https://gradienta.io/)| A pure css and jpg gradients |
-| [UI Gradients](https://uigradients.com/)| UI gradients color generator |
-
+| [Paletton.com] (https://paletton.com/#uid=1000u0kllllaFw0g0qFqFg0w0aF)| A free website for random colors sets|
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>
 </div>
@@ -164,7 +162,6 @@
 | [IconBros](https://www.iconbros.com) | 7843+ free icons grouped in 182 collections |
 | [LogoHub](https://logohub.io/) | Generate and download your logo for free in PNG and SVG format |
 | [Devicon](https://konpa.github.io/devicon/) | Devicon is a set of icons representing programming languages, designing & development tools |
-| [Material Design Icons](https://materialdesignicons.com/) | A icon collection allowing designers and developers targeting various platforms to download icons in the format, color and size they need for any project. | 
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>
@@ -336,7 +333,6 @@
 | [Shoelace.css](https://www.shoelace.style/)| Lightweight, forward-thinking CSS library built with future CSS syntax |
 | [MVP.css](https://andybrewer.github.io/mvp/) | A minimalist stylesheet for HTML elements. No class names, no frameworks, just semantic HTML and you're done |
 | [Blaze.css](http://blazecss.com/) | Open source modular CSS toolkit providing great structure for building websites quickly  |
-| [Turret CSS](https://turretcss.com/) | Turret CSS is a styles framework for development of responsive websites.  |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>
@@ -467,7 +463,6 @@
 | [Vuejsexamples](https://vuejsexamples.com)| A nice collection of useful vuejs UI components |
 | [Inkline](https://inkline.io)|Inkline is a modern UI/UX Framework for Vue.js designed for creating flawless responsive web applications |
 | [Vuesax](https://vuesax.com/)|Unique and reusable UI components |
-| [Antdv](https://antdv.com/)|UI library for Vue based on Ant Design |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
I have added one color link called Paletton's Colorpedia is the encyclopedia of colors.
It's still under development so some page is unavailable.

**Please delete this line before submitting**, _Pull request TITLE should look like this_: `[Resource] -> [Resource Section In Docs]`

# [Resource Name - Edit this line]

Edit this line with Small Description about new added resource 

Link: www.linkToResource

#### Checklist:

- [ ] I have performed a self-review of submitted resource and its follows the guidelines of the project.
