### PR TITLE
[darktable] -> [Downloadable Design Software]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -692,7 +692,7 @@
 | [Shapes.so](https://shape.so/pricing)| Icons that can be used as code in your projects  |
 | [Lunacy](https://icons8.com/lunacy) | Sketch for Windows |
 | [InVision Studio](https://www.invisionapp.com/studio)| Free screen designing tool from InVision |
-| [Darktable](https://www.invisionapp.com/studio)| Free & Open source photography workflow application and raw developer |
+| [Darktable](https://www.darktable.org/)| Free & Open source photography workflow application and raw developer |
 | [Inpixio photo Editor](https://www.inpixio.com/free-photo-editor)| Free Photo Editor: For windows only |
 
 <div align="right">


### PR DESCRIPTION
Fix the wrong link from https://www.invisionapp.com/studio to https://www.darktable.org/

# darktable

Edit this line with Small Description about new added resource

Link: https://www.darktable.org/

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
