### PR TITLE
[XP.css] -> [CSS Frameworks]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -414,6 +414,7 @@
 | [Turret CSS](https://turretcss.com/) | Turret CSS is a styles framework for development of responsive websites.  |
 | [Cutestrap](https://www.cutestrap.com/) | A strong, independent CSS Framework. |
 | [Shorthand](https://shorthandcss.com/) | Shorthand is a free and open source css framework, that allows you to make unique and modern design without writing any css |
+| [XP.css](https://botoxparty.github.io/XP.css/) | XP.css is an extention of 98.css. A CSS library for building interfaces that look like old UIs. |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
# XP.css

XP.css is an extension of 98.css. A CSS library for building interfaces that look like old UIs.

Link: https://botoxparty.github.io/XP.css/

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
