### PR TITLE
[SVG Gobbler] -> [Others]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -858,6 +858,7 @@
 | [html2pdf.js](https://ekoopmans.github.io/html2pdf.js/) | Client-side HTML-to-PDF rendering using pure JS. |
 | [CSS Reference](https://cssreference.io/) | A collection of all css properties and definitions in detail |
 | [Critical Path CSS Generator](https://www.sitelocity.com/critical-path-css-generator) | Generate critical css for your web pages |
+| [SVG Gobbler](https://github.com/rossmoody/svg-gobbler) | Browser extension to find SVGs on a webpage and download, copy to clipboard, or export as PNG. |
 
 
 <div align="right">


### PR DESCRIPTION
# SVG Gobbler

SVG Gobbler is a browser extension that hunts down the SVG content in your current tab, highlights unique attributes about it and gives you the option to download, copy to clipboard or export as PNG.

Link:
- https://github.com/rossmoody/svg-gobbler
- [Chrome Web Store](https://chrome.google.com/webstore/detail/svg-gobbler/mpbmflcodadhgafbbakjeahpandgcbch?hl=en-US&authuser=0)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
