### PR TITLE
Added Visual Studio Code Extensions section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@
 - [Design Inspiration](#Design-inspiration)
 - [Image Compression](#Image-compression)
 - [Chrome Extensions](#Chrome-extensions)
+- [VS Code Extensions](#Vs-code-extensions)
 - [Others](#others)
 
 ## UI Graphics
@@ -889,6 +890,23 @@
 | [Window Resizer](https://chrome.google.com/webstore/detail/window-resizer/kkelicaakdanhinjdeammmilcgefonfh?hl=en) | Resize the browser window to emulate various screen resolutions. |
 | [Responsive Viewer](https://chrome.google.com/webstore/detail/responsive-viewer/inmopeiepgfljkpkidclfgbgbmfcennb?hl=en) | Show multiple screens once, Responsive design tester |
 | [BrowserStack](https://chrome.google.com/webstore/detail/browserstack/nkihdmlheodkdfojglpcjjmioefjahjb?hl=en) | Instantly test your webpage on any desktop or mobile browser. |
+
+<div align="right">
+    <b><a href="#table-of-contents">↥ Back To Top</a></b>
+</div>
+
+## VS Code Extensions
+
+>Useful Chrome extensions for Designers and Web-Developers.
+
+| Marketplace URL&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | Description |
+| ----------------------- | ------------------ |
+| [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) | Launch a local development server with live reload feature for static & dynamic pages. |
+| [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) | Prettier is an opinionated code formatter. |
+| [GitLens — Git supercharged](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) | GitLens supercharges the Git capabilities built into Visual Studio Code. It helps you to visualize code authorship at a glance via Git blame annotations and code lens, seamlessly navigate and explore Git repositories, gain valuable insights via powerful comparison commands, and so much more. |
+| [Bracket Pair Colorizer](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2) | This extension allows matching brackets to be identified with colours. The user can define which tokens to match, and which colours to use. |
+| [Live Sass Compiler](https://marketplace.visualstudio.com/items?itemName=ritwickdey.live-sass) | A VSCode Extension that help you to compile/transpile your SASS/SCSS files to CSS files at realtime with live browser reload. |
+| [HTML CSS Support](https://marketplace.visualstudio.com/items?itemName=ecmel.vscode-html-css) | Missing CSS support for HTML documents. |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@
 - [Design Inspiration](#Design-inspiration)
 - [Image Compression](#Image-compression)
 - [Chrome Extensions](#Chrome-extensions)
-- [Visual Studio Code Extensions](#Vs-code-extensions)
+- [Visual Studio Code Extensions](#Visual-studio-code-extensions)
 - [Others](#others)
 
 ## UI Graphics

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@
 - [Design Inspiration](#Design-inspiration)
 - [Image Compression](#Image-compression)
 - [Chrome Extensions](#Chrome-extensions)
-- [VS Code Extensions](#Vs-code-extensions)
+- [Visual Studio Code Extensions](#Vs-code-extensions)
 - [Others](#others)
 
 ## UI Graphics
@@ -895,9 +895,9 @@
     <b><a href="#table-of-contents">↥ Back To Top</a></b>
 </div>
 
-## VS Code Extensions
+## Visual Studio Code Extensions
 
->Useful Chrome extensions for Designers and Web-Developers.
+>Useful Visual Studio Code extensions for Designers and Web-Developers.
 
 | Marketplace URL&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | Description |
 | ----------------------- | ------------------ |


### PR DESCRIPTION
Added __Visual Studio Code Extensions__ section right after __Chrome Extensions Section__ and added the following extensions:

- Live Server: https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer
- Prettier - Code formatter: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
- GitLens — Git supercharged: https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens
- Bracket Pair Colorizer 2: https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2
- Live Sass Compiler: https://marketplace.visualstudio.com/items?itemName=ritwickdey.live-sass
- HTML CSS Support: https://marketplace.visualstudio.com/items?itemName=ecmel.vscode-html-css