### PR TITLE
Removed Duplicate of `Illustration.co` from UI Graphics - Duplicate of `Illlustrations` -> Vectors & Clip Art

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -782,6 +782,7 @@
 | [GTmetrix](https://gtmetrix.com/) | Website Speed and Performance Optimization |
 | [Framer](https://www.framer.com/) | Is prototyping tool for teams |
 | [Draw.io](https://www.draw.io/) | Free online diagram editor tool |
+| [Giphy](https://giphy.com/) | The world's largest library of free GIFs, Stickers & memes! |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@
 | [thepatternlibrary](http://thepatternlibrary.com/)                                                       | Free beautiful background patterns                     |
 | [404 illustration](https://error404.fun/)                                                                | free illustrations for 404  pages |
 | [Drawkit.io](https://www.drawkit.io/)                                                                    | Illustrations for designers and startups                           |
-| [Undraw.co](https://undraw.co/)                                                                          | Open-source illustrations for any idea you can imagine and create  |                                    |
+| [Undraw.co](https://undraw.co/)                                                                          | Open-source illustrations for any idea you can imagine and create  |
 | [Manypixels.co](https://www.manypixels.co/gallery/)                                                      | Monochromatic, Isometric high quality illustrations                |
 | [Open Peeps](https://www.openpeeps.com/)                                                                 | Hand drawn illustration library                                    |
 | [UI Space](https://uispace.net/)                                                                         | Thousands of great UI freebies                                     |

--- a/readme.md
+++ b/readme.md
@@ -783,7 +783,6 @@
 | [GTmetrix](https://gtmetrix.com/) | Website Speed and Performance Optimization |
 | [Framer](https://www.framer.com/) | Is prototyping tool for teams |
 | [Draw.io](https://www.draw.io/) | Free online diagram editor tool |
-| [Giphy](https://giphy.com/) | The world's largest library of free GIFs, Stickers & memes! |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>

--- a/readme.md
+++ b/readme.md
@@ -45,8 +45,7 @@
 | [thepatternlibrary](http://thepatternlibrary.com/)                                                       | Free beautiful background patterns                     |
 | [404 illustration](https://error404.fun/)                                                                | free illustrations for 404  pages |
 | [Drawkit.io](https://www.drawkit.io/)                                                                    | Illustrations for designers and startups                           |
-| [Undraw.co](https://undraw.co/)                                                                          | Open-source illustrations for any idea you can imagine and create  |
-| [Illustration.co](https://illlustrations.co/)                                                            | Open-source illustrations kit                                      |
+| [Undraw.co](https://undraw.co/)                                                                          | Open-source illustrations for any idea you can imagine and create  |                                    |
 | [Manypixels.co](https://www.manypixels.co/gallery/)                                                      | Monochromatic, Isometric high quality illustrations                |
 | [Open Peeps](https://www.openpeeps.com/)                                                                 | Hand drawn illustration library                                    |
 | [UI Space](https://uispace.net/)                                                                         | Thousands of great UI freebies                                     |


### PR DESCRIPTION

Retained the `Illlustrations` -> Vectors & Clip Art and removed the duplicate entry