### PR TITLE
Updated non functioning URL for PaymentFont ->Icon Fonts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -250,7 +250,7 @@
 | [Material Design Iconic Font](http://zavoloklom.github.io/material-design-iconic-font/index.html) | Material design icon font |
 | [Vscode Codicons](https://microsoft.github.io/vscode-codicons/dist/codicon.html) | The icon font from Visual Studio Code |
 | [Devicon](https://konpa.github.io/devicon/) | Devicon is a set of icons representing programming languages, designing & development tools |
-| [PaymentFont](https://paymentfont.com/) | A sleek webfont for payment operators and methods. Featuring 116 icons |
+| [PaymentFont](https://github.com/AlexanderPoellmann/PaymentFont) | A sleek webfont for payment operators and methods. Featuring 116 icons |
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | Weather Icons is the only icon font with 222 weather themed icons |
 | [Stroke 7](https://themes-pixeden.com/font-demos/7-stroke/index.html) | 202 thin stroke icons inspired by iOS 7 |
 | [Jam Icons](https://jam-icons.com/) | 890+ handcrafted icons to make your web app awesome |


### PR DESCRIPTION

The current URL for PaymentFont `https://paymentfont.com/` does not resolve. Therefore, adding the URL to the corresponding github project.