### PR TITLE
Updated Vercel UI's repository link.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -616,7 +616,7 @@
 | [React Suite](https://rsuitejs.com/en/)| A suite of React components, sensible UI design, and a friendly development experience. |
 | [React Spring](https://www.react-spring.io/)| Spring-physics based animation library for React applications. |
 | [Recharts](http://recharts.org/en-US/)| A composable charting library built on React components. |
-| [Vercel UI](https://github.com/zeit-ui/react) | Modern and minimalist React UI library |
+| [Vercel UI](https://github.com/geist-org/react) | Modern and minimalist React UI library |
 | [Framer Motion](https://www.framer.com/motion/) | A React library to power production-ready animations. |
 | [React Spectrum](https://react-spectrum.adobe.com/react-spectrum/index.html) | A React implementation of Spectrum, Adobe’s design system. |
 | [React tsParticles](https://particles.matteobruni.it/)| A lightweight React component for creating particles |


### PR DESCRIPTION
Vercel UI (Zeit UI) have recently changed it's organization name to Geist UI [due to some copyright issues](https://github.com/geist-org/react/issues/370).
This PR updates the link to it's repository from `https://github.com/zeit-ui/react` → `https://github.com/geist-org/react`.