### PR TITLE
[DevDocs] -> [Others] Fixed the error in markdown for resource name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -968,7 +968,7 @@
 | [Gerillass](https://gerillass.com/) | Gerillass is a website development tool built on top of Sass with a set of Sass mixins and functions for frontend developers to generate scalable CSS outputs. |
 | [Sketchize](https://www.sketchize.com/) | Sketchize is built for UI/UX Designers to help them design lovely apps for mobile, tablet, and desktop devices. |
 | [{CSS}Portal](https://www.cssportal.com/) | CSSPortal is home to a large range of CSS generators, tools and resources. |
-| [DevDocs}(https://devdocs.io/) | DevDocs combines multiple API documentations in a fast, organized, and searchable interface. |
+| [DevDocs](https://devdocs.io/) | DevDocs combines multiple API documentations in a fast, organized, and searchable interface. |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
Hey maintainer,
This is my to-go place for all finding resources for all my dev needs and scrolling through it I found a minor error in the link to the resource name. So I fixed a bracket error in markdown for a link to the resource name.
I am not adding a new resource so I wasn't sure about the format of PR, apologies if I this isn't the right way.
Thank you for this amazing compilation of resources.