### PR TITLE
Vecta Nano -> Image Compression

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -988,6 +988,7 @@
 | [EZGif](https://ezgif.com/)| Animated GIF maker and Image editor including Image optimization and supports WebP conversion |
 | [OnlinePngtools](https://onlinepngtools.com/resize-png)| Resize png for without losing transparent background. |
 | [Verexif](https://www.verexif.com/en/) | Remove meta tags in image in order to reduce image size and increase privacy security |
+| [Vecta Nano](https://vecta.io/nano) | Uses lossless compression to compress inefficient SVG codes by removing unnecessary data. (Free & Paid)  |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
# Vecta Nano

Vecta Nano is a Free and Paid SVG compressor tool that uses lossless techniques to compress inefficient SVG codes by removing unnecessary data, resulting in the same image, but large differences in file size.
The Free Option allows converting 10 SVG at one time.

Link: https://vecta.io/nano

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
