### PR TITLE
Svelte Flat UI -> Svelte UI Components (UPDATE LINK)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -794,7 +794,7 @@
 | ----------------------- | ------------------ |
 | [Svelte Material UI](https://sveltematerialui.com/)| UI library for Svelte based on Material Design |
 | [SvelteStrap](https://bestguy.github.io/sveltestrap/)| UI library for Svelte based on the Bootstrap framework |
-| [Svelte Flat UI](https://svelteui.js.org/#/checkbox)|UI library for Svelte based on Flat Design |
+| [Svelte Flat UI](https://svelteui.js.org/)|UI library for Svelte based on Flat Design |
 | [Svelte Particles](https://particles.matteobruni.it/)| A lightweight Svelte component for creating particles |
 
 <div align="right">


### PR DESCRIPTION
Svelte Flat UI link would redirect to subpage instead of homepage

# Resource Name - Svelte Flat UI

This resource isn't added, the link to it has been updated

Link: https://svelteui.js.org

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
