### PR TITLE
Delete [Fontastic.me] -> [Icon Fonts]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -308,7 +308,6 @@
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | Weather Icons is the only icon font with 222 weather themed icons |
 | [Stroke 7](https://themes-pixeden.com/font-demos/7-stroke/index.html) | 202 thin stroke icons inspired by iOS 7 |
 | [Jam Icons](https://jam-icons.com/) | 890+ handcrafted icons to make your web app awesome |
-| [Fontastic.me](http://fontastic.me/) | Create your custom icon fonts in seconds. Over 9,000 icons available to pick from or upload your custom svg |
 | [Fontello](http://fontello.com/)| 200+ web icons where you can customize the names or codes of icons. |
 | [Linea](https://linea.io/)| Linea: Featuring 750+ Free Icons |
 | [Unicons](https://iconscout.com/unicons)| A set of 1100+ Free line style icons available as web font, SVG icons, and as components for JS frameworks like React, Vue and React Native. |


### PR DESCRIPTION
# Delete Fontastic.me - Broken Link

On diagnosing a slow-loading Wordpress site, I discovered Fontastic.me, along with their CDN, disappeared without trace in February 2021.

Link: http://fontastic.me

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
