### PR TITLE
Delete AOS redundancy. It's already added on JavaScript Animation Lib…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -594,7 +594,6 @@
 | [Keyframes.app](https://keyframes.app/)| A graphical user interface for generating custom CSS keyframe animations |
 | [thoughtbot](https://thoughtbot.com/blog/transitions-and-transforms)| CSS Transitions and Transformations for Beginners |
 | [SVG Artista](https://svgartista.net/)| A useful tool to animate stroke and fill properties in SVG images with plain CSS code |
-| [AOS](https://github.com/michalsnik/aos)| Animate on Scroll Library |
 | [AnimXYZ](https://animxyz.com/)| AnimXYZ helps you create, customize, and compose animations for your website. Built for Vue, React, SCSS, and CSS |
 
 <div align="right">


### PR DESCRIPTION
# AOS

Remove AOS because It's already added on JavaScript Animation Lib

Link: https://michalsnik.github.io/aos/

#### Checklist:

- [X] I have performed a self-review of submitted resource and its follows the guidelines of the project.
