### PR TITLE
[Lospec Palette List] -> [Colors]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,6 +191,7 @@
 | [FarbVelo](https://farbvelo.elastiq.ch/) | A random color palette generator |
 | [Veranda Color](https://verandacolor.com) | Browse color palettes made by other designers, generate and submit your own |
 | [Duo](https://duo.alexpate.uk/) | Duo is a collection of colour combinations that I’ve curated from personal projects or that I’ve come across on the web. |
+| [Lospec Palette List](https://lospec.com/palette-list) | The Lospec Palette List is a database of palettes for pixel art. |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
# Lospec Palette List

The Lospec Palette List is a database of palettes for pixel art. We include both palettes that originate from old hardware that could only display a few colors, as well as palettes created by pixel artists specifically for making art. All palettes can be downloaded and imported into your pixelling software of choice.

Link: https://lospec.com/palette-list

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.