### PR TITLE
Paletter -> Removed dead link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,6 @@
 | [HTML Color Codes](https://htmlcolorcodes.com/)| Get HTML color codes, Hex color codes, RGB and HSL values with our color picker, color chart and HTML color names |
 | [Colors & Fonts](https://www.colorsandfonts.com/)| A curated library of colors, fonts and resources |
 | [Palette List](https://www.palettelist.com/)| Pick 2 colors you like and the tool generates thousands of palettes for you. |
-| [Paletter](https://www.paletter.app) | Create a color palette from a single color |
 | [Google Material Color Tool](https://material.io/resources/color/)| Official Google Material Color Palette Tool|
 | [Material Palette](https://www.materialpalette.com/)| Free to pick palettes, icons and colors for Material Design|
 | [ColorSpace](https://mycolor.space/)| Generate nice color palettes from one color |


### PR DESCRIPTION
# Paletter

The link to Paletter was present, but pointed to a deadlink

Link: [Paletter](https://www.paletter.app)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
