### PR TITLE
Templated.co -> Deleted dead/spam link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -482,7 +482,6 @@
 | ----------------------- | ------------------ |
 | [HTML5Up](https://html5up.net/)| Very modern, unique responsive HTML5/CSS3 themes |
 | [Templatemo](https://templatemo.com/)| Minimal, resume, gallery themes and more |
-| [Templated.co](https://templated.co/)| Tons of minimalistic HTML5/CSS3 themes |
 | [FreeHTML5](https://freehtml5.co/)| Free & premium HTML5 and Bootstrap themes |
 | [StyleShout](https://www.styleshout.com/free-templates/)| Brilliantly crafted free website templates |
 | [Start Bootstrap](https://startbootstrap.com/)| Bootstrap starter themes |


### PR DESCRIPTION
# Templated.co

The link to Templated.co was present, but pointed to a dead page.

Link: [Templated.co](https://templated.co/)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.