### PR TITLE
Tailwindow -> Deleted deadlink

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -719,7 +719,6 @@
 | [Soft Components](https://soft-components-docs.web.app/)| A set of framework-agnostic web components based on neumorphic design. |
 | [Fast](https://www.fast.design/)| An interface system that can be used with modern Web Frameworks such as React, Vue and Angular. |
 | [LottieFiles ](https://lottiefiles.com/)| Interactive animations in many formats like json,gif and mp4, libraries and plugins for Web & Mobile . |
-| [Tailwindow ](https://component.tailwindow.com/)| Components created using Tailwind CSS utilities class, so it can be customized to make themes easily. |
 | [Kutty](https://kutty.netlify.app/)| A set of accessible and reusable prebuilt Tailwind components that are commonly used in web applications. |
 | [Tailwind Templates](https://tailwindtemplates.io/)| A free collection of Tailwindcss Templates - tailwind components for rapid UI development. |
 | [Stitches](https://stitches.hyperyolo.com/)| An HTML template generator using functional css. |


### PR DESCRIPTION
# Tailwindow

The link to Tailwindow was present, but pointed to a dead page.

Link: [Tailwindow ](https://component.tailwindow.com/)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.