### PR TITLE
SoftUI -> Deleted dead link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -997,7 +997,6 @@
 | [CTA Button Maker](https://www.clickminded.com/button-generator/)| Create call to action buttons |
 | [Blobmaker](https://www.blobmaker.app/)| Blobmaker is a free generative design tool, to help you quickly create random, unique, and organic-looking SVG shapes.  |
 | [Personas](https://personas.draftbit.com/)| A playful avatar generator for the modern age  |
-| [SoftUI](https://www.softui.io)| A Soft UI (neumorphism) CSS generator  |
 | [Photopea](https://www.photopea.com)| An Online Photoshop editor  |
 | [Excalidraw](https://excalidraw.com/)| Virtual whiteboard for sketching hand-drawn like diagrams  |
 | [Diagrams](https://www.diagrams.net/)| Diagram software and Flowchart maker  |


### PR DESCRIPTION
# SoftUI

The link to SoftUI was present, but pointed to a dead page.

Link: [SoftUI](https://www.softui.io)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.