### PR TITLE
Rimble -> Deleted dead link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -766,7 +766,6 @@
 | [Evergreen](https://evergreen.segment.com/)| Design system for React |
 | [Rebass](https://rebassjs.org/)| React primitive UI components built with styled system |
 | [Grommet](https://v2.grommet.io/)| mobile first UI component library |
-| [Rimble](https://rimble.consensys.design/)| React design kit, library and guides |
 | [Landing Page Template](https://github.com/cruip/open-react-template/)| Open source landing page template for react |
 | [Elemental UI](http://elemental-ui.com/)| A UI Toolkit for React.js Websites and Apps |
 | [Ant Design](https://ant.design/)| Open source design React UI library. |


### PR DESCRIPTION
# Rimble

The link to Rimble was present, but pointed to a dead page.

[Rimble](https://rimble.consensys.design/)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.