### PR TITLE
NGX Foundation -> Deleted dead link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -877,7 +877,6 @@
 | [Multi select dropdown](https://www.npmjs.com/package/ng-multiselect-dropdown) | For multi select drop-dowm in forms |
 | [NG Particles](https://particles.matteobruni.it/)| A lightweight Angular component for creating particles |
 | [Covalent UI](https://teradata.github.io/covalent/v3/#/)| Angular UI Platform focused on solving common enterprise needs |
-| [NGX Foundation](https://ngxfoundation.com/)| UI framework based on the veteran CSS framework foundation |
 | [Clarity](https://clarity.design/)| CSS based Angular UI framework developed by VMware group |
 | [Taiga UI](https://taiga-ui.dev/)| Taiga UI is fully-treeshakable Angular UI Kit consisting of multiple base libraries and several add-ons. |
 


### PR DESCRIPTION
# NGX Foundation

The link to NGX Foundation was present, but pointed to a dead page.

[NGX Foundation](https://ngxfoundation.com/)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.