### PR TITLE
Devicon -> Updated link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -316,7 +316,7 @@
 | [Material Palette](https://www.materialpalette.com/icons)| Free to pick palettes, icons and colors for Material Design]|
 | [Material Design Iconic Font](http://zavoloklom.github.io/material-design-iconic-font/index.html) | Material design icon font |
 | [Vscode Codicons](https://microsoft.github.io/vscode-codicons/dist/codicon.html) | The icon font from Visual Studio Code |
-| [Devicon](https://konpa.github.io/devicon/) | Devicon is a set of icons representing programming languages, designing & development tools |
+| [Devicon](https://devicon.dev) | Devicon is a set of icons representing programming languages, designing & development tools |
 | [PaymentFont](https://github.com/AlexanderPoellmann/PaymentFont) | A sleek web font for payment operators and methods. Featuring 116 icons |
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | Weather Icons is the only icon font with 222 weather themed icons |
 | [Stroke 7](https://themes-pixeden.com/font-demos/7-stroke/index.html) | 202 thin stroke icons inspired by iOS 7 |


### PR DESCRIPTION
# Devicon

The link to Devicon was present, but pointed to [a dead page](https://konpa.github.io/devicon/), updated the resource's link to the correct one.

Link: [Devicon](https://devicon.dev)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
