### PR TITLE
Material Design Resources -> Others

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1199,7 +1199,7 @@
 | [The Web Toolbox](https://thewebtoolbox.cc/)| A collection of handy, free-to-use tools for web developers, programmers and designers. |
 | [WebDevTrick](https://webdevtrick.com/)| A famous blog for many amazing HTML, CSS, JQuery designs. |
 | [css-tricks](https://css-tricks.com/)| Free CSS tricks and some unique ideas for beginners and advanced |
-| [Material Design Resizer](https://material.io/resources/resizer/)| An interactive viewer that helps designers test material design breakpoints across desktop, mobile, and tablet |
+| [Material Design Resources](https://material.io/resources)| Use Material tools, downloads, and interactive projects to simplify your workflow. |
 | [Nodesign.dev](https://nodesign.dev) | A collection of tools for developers who have little to no artistic talent|
 | [A11ygator](https://a11ygator.chialab.io/)| A web tool to scan websites against WCAG rules |
 | [Commitizen](http://commitizen.github.io/cz-cli/)| Command line tool to formatted commit messages according to the standards |


### PR DESCRIPTION
# Material Design Resources

The link to [Material Design Resizer](https://material.io/resources/resizer/) was present, but linked to a dead page. I changed the link to the enclosing [Material Design Resources](https://material.io/resources), which the Resizer used to be a part of.

Link: [Material Design Resources](https://material.io/resources)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
