### PR TITLE
Responsively -> Others

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1213,7 +1213,7 @@
 | [kangax-js-compat-table](https://kangax.github.io/compat-table/es6/) | Check JavaScript versions (ES5, ES6, ES2016+ etc.) compatibility across different compilers, servers/runtimes and platforms (Desktop and Mobile).|
 | [mydevice.io](https://www.mydevice.io/)| Most commonly used device resolutions including phones and tablets |
 | [Codepen](https://codepen.io/) | Build, test and discover frontend code. |
-| [Responsively](https://manojvivek.github.io/responsively-app/) | A tool for designers and frontend developers to design and debug their in all platforms with ease |
+| [Responsively](https://responsively.app) | A tool for designers and frontend developers to design and debug their in all platforms with ease |
 | [html2pdf.js](https://ekoopmans.github.io/html2pdf.js/) | Client-side HTML-to-PDF rendering using pure JS. |
 | [CSS Reference](https://cssreference.io/) | A collection of all css properties and definitions in detail |
 | [Critical Path CSS Generator](https://www.sitelocity.com/critical-path-css-generator) | Generate critical css for your web pages |


### PR DESCRIPTION
# Responsively

The link to Responsively was present, but linked to a [no longer existing GitHub repo](https://manojvivek.github.io/responsively-app/). Updated the link to point to the app's [landing page](https://responsively.app).

Link: [Responsively](https://responsively.app)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
