### PR TITLE
Match Stick -> Deleted dead link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1228,7 +1228,6 @@
 | [{CSS}Portal](https://www.cssportal.com/) | CSSPortal is home to a large range of CSS generators, tools and resources. |
 | [DevDocs](https://devdocs.io/) | DevDocs combines multiple API documentations in a fast, organized, and searchable interface. |
 | [papersizes](https://papersizes.io/) | The best resource for International Paper Sizes, Dimensions & Formats. |
-| [Match Stick](https://matchstick.xyz/) | Visually compare your code and designs. Compare your mockups with your live website to pinpoint any missing details. |
 | [flexboxfroggy](http://flexboxfroggy.com/) | Help Froggy and friends by writing CSS code! |
 | [Designbetter Books](https://www.designbetter.co/books) | Essential reading on the practices that propel the best design teams forward. |
 | [OverAPI](https://overapi.com/) | Collection Of All Cheat Sheets. |


### PR DESCRIPTION
# Match Stick

The link to Match Stick was present, but pointed to a dead page.

Link: [Match Stick](https://matchstick.xyz/)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.