### PR TITLE
FontSpark -> Deleted dead link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,6 @@
 | [TypeKit Practice](https://practice.typekit.com/)| Learn about typography practices |
 | [Fontjoy](https://fontjoy.com/)| Generate font pairing in one click |
 | [Golden Ratio](https://grtcalculator.com/)| Golden Ratio Typography Calculator |
-| [FontSpark](https://fontspark.app/) | Discover Better Fonts |
 | [FontGet](https://www.fontget.com/) | Has a variety of fonts available to download and sorted neatly with tags |
 | [FontPair](https://fontpair.co/) | Helps you pair Google Fonts together
 | [Font Space](https://www.fontspace.com/)| A designer-centered free font website that has quick customizable previews |


### PR DESCRIPTION
# FontSpark

The link to FontSpark was present, but pointed to a dead page.

Link: [FontSpark](https://fontspark.app/)

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.