### PR TITLE
tsParticles -> Fixed tsParticles URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -652,7 +652,7 @@
 | [Animate On Scroll](https://michalsnik.github.io/aos/)| Animate on scroll library to reveal animations when You scroll. |
 | [Tilt.js](http://gijsroge.github.io/tilt.js/)| A tiny requestAnimationFrame powered 60+fps lightweight parallax hover tilt effect for jQuery. |
 | [Roughnotation](https://roughnotation.com/)| Rough Notation is a small JavaScript library to create and animate annotations on a web page |
-| [tsParticles](https://particles.matteobruni.it/)| A lightweight library for creating particles, an improved version of the abandoned and obsolete particles.js |
+| [tsParticles](https://particles.js.org/)| A lightweight library for creating particles, an improved version of the abandoned and obsolete particles.js |
 | [Particles.js](https://vincentgarreau.com/particles.js/)| A lightweight JavaScript library for creating particles |
 | [mo.js](https://mojs.github.io/)| The motion graphics toolbelt for the web |
 | [Lightbox2](https://lokeshdhakar.com/projects/lightbox2/)| A small JS library to overlay images on top of the current page. |


### PR DESCRIPTION
# tsParticles

tsParticles - https://particles.js.org

tsParticles had a broken URL, which was the previous one, updated to the correct one

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
