### PR TITLE
[AniX] -> [CSS Animations]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -674,7 +674,7 @@
 | [CSS Loaders & Spinners](https://cssloaders.github.io/)| This is a library having a collection of different types of CSS loaders, spinners |
 | [Motion One](https://motion.dev/)| A new animation library, built on the Web Animations API for the smallest filesize and the fastest performance. |
 | [pocoloco](https://pocoloco.io/)| Generate dynamic backgrounds for your website |
-| [AniX](https://drawcall.github.io/AniX/)| Super easy and lightweight css animation library. |
+| [AniX](https://adajuly.github.io/AniX/)| Super easy and lightweight css animation library. |
 | [AOS](https://michalsnik.github.io/aos/) | Animate On Scroll Library. |
 | [Animatopy](https://sarthology.github.io/Animatopy/) | Just-add-water CSS animations snippets |
 


### PR DESCRIPTION
# AniX

The [existing link](https://drawcall.github.io/AniX/) to AniX is no longer working. The repo URL redirects from [drawcall](https://github.com/drawcall/AniX/) to [adajuly](https://github.com/adajuly/AniX).

Link: https://adajuly.github.io/AniX/

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
