### PR TITLE
[shadcn-svelte] -> [Svelte UI Libraries]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -990,6 +990,7 @@
 | [Svelteit](https://docs.svelteit.dev)| A minimalistic UI/UX component library for Svelte and Sapper projects |
 | [Carbon Components Svelte](https://carbon-components-svelte.onrender.com/)| A component library that implements the Carbon Design System, an open source design system by IBM.|
 | [Radix Svelte](https://www.radix-svelte.com/)| This is a port of Radix UI for Svelte.|
+| [shadcn-svelte](https://www.shadcn-svelte.com/)| shadcn-svelte is an unofficial community-led Svelte port of shadcn/ui.|
 
 
 <div align="right">


### PR DESCRIPTION
# shadcn-svelte

[shadcn-svelte](https://www.shadcn-svelte.com/) is an unofficial community-led [Svelte](https://svelte.dev/) port of [shadcn/ui](https://ui.shadcn.com/).

Link: https://www.shadcn-svelte.com/

#### Checklist:

- [X] I have performed a self-review of submitted resource and its follows the guidelines of the project.
