### PR TITLE
Added Materio Free Bootstrap 5 Admin Template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -839,6 +839,7 @@
 | [Choc UI](https://choc-ui.com/)| Choc UI is a set of accessible and reusable components that are commonly used in web applications. |
 | [Elementz](https://elementz.style/)| A React Component library for buliding modern applications easily & quickly. |
 | [Radix UI](https://www.radix-ui.com/)| Unstyled, accessible components for building high‑quality design systems and web apps in React |
+| [Materio MUI React NextJS Admin Template](https://github.com/themeselection/materio-mui-react-nextjs-admin-template-free)| Most Powerful & Comprehensive Open-source MUI React NextJS Admin Dashboard Template built for developers. |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
Added Materio Free Bootstrap 5 Admin Template & corrected spelling in Sneat Bootstrap 5 Admin Template Description

 `[Materio Free Bootstrap 5 HTML Admin Template] -> [HTML & CSS Templates]`

# Materio Free Bootstrap 5 HTML Admin Template

Most Powerful & Comprehensive Free Bootstrap 5 HTML Admin Dashboard Template built for developers! 

Link: https://github.com/themeselection/materio-bootstrap-html-admin-template-free

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
