### PR TITLE
update NG Semantic link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -983,7 +983,7 @@
 | [PrimeNG](https://www.primefaces.org/primeng/#/)| Powerful UI component library for Angular |
 | [Onsen Angular](https://onsen.io/angular2/)| Hybrid mobile and PWA UI library for Angular and Onsen UI |
 | [NG Lightning](https://ng-lightning.github.io/ng-lightning/#/)| Native Angular components & directives for Lightning Design System |
-| [NG Semantic](https://ng-semantic.herokuapp.com/)| UI library for Angular based on Semantic UI |
+| [NG Semantic](https://github.com/vladotesanovic/ngSemantic)| UI library for Angular based on Semantic UI |
 | [Nebular](https://akveo.github.io/nebular/)| Customizable UI Kit, Auth & Security for Angular |
 | [Alyle UI](https://alyle.io/)| Minimal components set for Angular |
 | [NGX Bootstrap](https://valor-software.com/ngx-bootstrap/#/)| Another UI library for Angular based on the Bootstrap framework |


### PR DESCRIPTION
# NG Semantic

not sure whether this library is still maintained or not, but the old link is dead, so I modified with github repo link instead

Link: https://github.com/vladotesanovic/ngSemantic

#### Checklist:

- [X] I have performed a self-review of submitted resource and its follows the guidelines of the project.
