### PR TITLE
@tsparticles/svelte seem no longer available

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1012,7 +1012,6 @@
 | [Svelte Material UI](https://sveltematerialui.com/)| UI library for Svelte based on Material Design |
 | [SvelteStrap](https://bestguy.github.io/sveltestrap/)| UI library for Svelte based on the Bootstrap framework |
 | [Svelte Flat UI](https://svelteui.js.org/)|UI library for Svelte based on Flat Design |
-| [@tsparticles/svelte](https://github.com/matteobruni/tsparticles/svelte)| A lightweight Svelte component for creating particles |
 | [Attractions](https://illright.github.io/attractions/)| A pretty cool UI kit for Svelte |
 | [Svelteit](https://docs.svelteit.dev)| A minimalistic UI/UX component library for Svelte and Sapper projects |
 | [Carbon Components Svelte](https://carbon-components-svelte.onrender.com/)| A component library that implements the Carbon Design System, an open source design system by IBM.|


### PR DESCRIPTION
`[@tsparticles/svelte] -> remove [@tsparticles/svelte]`

# Resource Name - @tsparticles/svelte

@tsparticles/svelte ui library seem no longer available

[Link: @tsparticles/svelte](https://github.com/matteobruni/tsparticles/svelte)
#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
