### PR TITLE
[Neptune CSS] -> [CSS Frameworks]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -661,7 +661,6 @@ Available for MacOS, Linux, & Windows<br>
 | [clay.css](https://github.com/codeAdrian/clay.css) | Extensible and configurable micro CSS util class and SASS mixin for adding claymorphism styles to your components. |
 | [BeerCSS](https://www.beercss.com) | Build Material Design interfaces in record time, without stress for devs 🍻. The first CSS framework that implements Material Design 3. |
 | [UnoCSS](https://unocss.dev/) | UnoCSS is the instant atomic CSS engine, that is designed to be flexible and extensible. The core is un-opinionated, and all the CSS utilities are provided via presets. |
-| [Neptune CSS](neptunecss.org) | Neptune CSS is a lightweight CSS framework. Use it to develop your websites faster. |
 | [StyleX](https://stylexjs.com/) | StyleX is a simple, easy-to-use JavaScript syntax and compiler for styling web apps. |
 | [Orbit](https://github.com/zumerlab/orbit) | Orbit is the first CSS framework for creating simple or complex radial interfaces. |
 


### PR DESCRIPTION
Removing broken link to neptunecss.org, which returns a 404. 
The Neptune CSS GitHub repo appears to be abandoned, with no activity in 3 years. 

Related to issue #1542.

