### PR TITLE
Add PageGuard - free website health scanner

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1457,6 +1457,7 @@ Available for MacOS, Linux, & Windows<br>
 | [Material Design Resources](https://material.io/resources)| Use Material tools, downloads, and interactive projects to simplify your workflow. |
 | [Nodesign.dev](https://nodesign.dev) | A collection of tools for developers who have little to no artistic talent|
 | [A11ygator](https://a11ygator.chialab.io/)| A web tool to scan websites against WCAG rules |
+| [PageGuard](https://pageguard.org) | Free website health scanner — check accessibility, SEO, performance & best practices in one scan |
 | [Commitizen](http://commitizen.github.io/cz-cli/)| Command line tool to formatted commit messages according to the standards |
 | [CleanCss](https://www.cleancss.com/)| Tool For Code Formatter, Minifier, File Converter |
 | [Tiny helpers](https://tiny-helpers.dev/)| A collection of free single-purpose online tools for web developers |


### PR DESCRIPTION
## Description

Adds [PageGuard](https://pageguard.org) to the **Others** section, right after A11ygator (which is already listed there for WCAG scanning).

## What is PageGuard?

PageGuard is a free website health scanner that checks:
- **Accessibility** — WCAG 2.1 compliance, ADA Title II requirements
- **SEO** — meta tags, structured data, canonical URLs
- **Performance** — Core Web Vitals (LCP, INP, CLS)
- **Best Practices** — security headers, HTTPS, robots.txt

No login required for basic scans. Returns a score (0–100) across all four dimensions.

## Why it fits here

The Others section already includes A11ygator (WCAG scanner) and similar web developer tools. PageGuard extends that with a broader health scan covering accessibility plus SEO, performance, and best practices — useful for any developer wanting a quick audit of their project.

## Links

- Tool: https://pageguard.org
- API docs: https://pageguard.org/docs
- Free, no account needed for single scans