### PR TITLE
Add A1 Gallery to Design Inspiration section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1302,6 +1302,7 @@ Available for MacOS, Linux, & Windows<br>
 | [bestwebdesigntools](https://www.bestwebdesigntools.com/)| Discover latest design tools, agencies and landing pages templates across web|
 | [App Motion](https://appmotion.design/)| Explore the best, hand-picked app motion design |
 | [Uiland Design](https://uiland.design/)| Home of the best mobile ui inspirations from top companies in the world |
+| [A1 Gallery](https://www.a1.gallery)| Hand-curated gallery of 1,000+ websites filterable by technology stack, font, style, colour, creator, type, and category |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
A1 Gallery (https://www.a1.gallery) is a hand-curated gallery of 1,000+ websites filterable by technology stack, font, style, colour, creator, type, and category.

The technology filter is the detail that makes it particularly useful for developers: you can browse sites built with specific frameworks (Next.js, Webflow, Framer, Shopify, etc.) and combine that with style and category filters. It fills a different niche from the general inspiration galleries already in this section — it's useful when you want to see what's being built in a specific tool, not just what looks good.

Free, updated daily.