### PR TITLE
Add GEOScore - AI search visibility scanner

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1510,6 +1510,7 @@ Available for MacOS, Linux, & Windows<br>
 | [RunJS](https://runjs.app/play) | Free online JavaScript playground.  |
 | [Pillarstack](https://www.pillarstack.com/) | Assorted resources for frontend developers and web designers.  |
 | [ToolsHref](https://toolshref.com) - Online Java code analyzer and JSON-to-Mermaid visualization tool. Multiple Dev Tools    |
+| [GEOScore](https://geoscoreai.com/) | Free AI search visibility scanner that checks 11 GEO signals including robots.txt, llms.txt, structured data, and citation readiness for AI search engines. |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
## Description

Adding [GEOScore](https://geoscoreai.com/) to the **Others** section.

GEOScore is a free AI search visibility scanner that checks 11 GEO (Generative Engine Optimization) signals including robots.txt, llms.txt, structured data, and citation readiness for AI search engines like ChatGPT, Perplexity, and Google AI Overviews.

## Why it belongs here

As AI-powered search engines become mainstream, developers need tools to ensure their websites are discoverable by AI. GEOScore provides a free, instant audit of a site's AI search readiness - useful for any web developer building modern sites.