### PR TITLE
Add HTML Design to HTML & CSS Templates section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -589,6 +589,7 @@ Available for MacOS, Linux, & Windows<br>
 | [mashup-template](http://www.mashup-template.com/templates.html)| HTML5/CSS3 Free Templates |
 | [Sneat Bootstrap 5 HTML Admin Template](https://github.com/themeselection/sneat-html-admin-template-free)| Open-source & Easy to us Bootstrap 5 HTML Admin Template with Elegant Design & Unique Layout.|
 | [HTMLrev](https://htmlrev.com) | Free beautiful HTML5 templates and landing pages |
+| [HTML Design](https://html.design) | 800+ free HTML, Bootstrap & PSD templates across 40+ categories. No registration required |
 | [Horizon UI](https://horizon-ui.com/) | Trendiest open source Admin Template for React |
 | [KeenThemes](https://keenthemes.com/) | Free and Pro Html/Css3, Bootstrap5, Vue, React, Laravel templates |
 | [ScrewFast](https://github.com/mearashadowfax/ScrewFast) | Open-source Astro website template with sleek, customizable TailwindCSS components |


### PR DESCRIPTION
## Addition

Added **[HTML Design](https://html.design)** to the HTML & CSS Templates section.

**About HTML Design:**
- 800+ free HTML, Bootstrap & PSD templates
- 40+ categories (business, portfolio, restaurant, education, ecommerce, etc.)
- No registration required — all templates are free to download
- Active since 2017 with regular new releases
- Licensed for personal and commercial use (CC 3.0)

This resource fits well alongside the existing template sites in this section.