### PR TITLE
Add Toolbox Kit to Others

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1515,6 +1515,7 @@ Available for MacOS, Linux, & Windows<br>
 | [RunJS](https://runjs.app/play) | Free online JavaScript playground.  |
 | [Pillarstack](https://www.pillarstack.com/) | Assorted resources for frontend developers and web designers.  |
 | [ToolsHref](https://toolshref.com) - Online Java code analyzer and JSON-to-Mermaid visualization tool. Multiple Dev Tools    |
+| [Toolbox Kit](https://toolbox-kit.com/) | 150+ free browser-based developer tools: JSON formatter, diff checker, regex tester, JWT decoder, CSS generators, SVG optimizer, color tools, and hash/QR generators. Runs client-side, no signup. |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
Adding [Toolbox Kit](https://toolbox-kit.com/) to the `## Others` section.

Toolbox Kit is a free collection of 150+ browser-based developer tools: JSON formatter, diff checker, regex tester, JWT decoder, CSS generators, SVG optimizer, color tools, hash and QR generators. Everything runs client-side so data never leaves the tab. No signup required.

Fits alongside existing entries like Tiny helpers, SmallDev.tools, CleanCss, Angry Tools, ExtendsClass, and Code Beautify in the Others section.

Disclosure: I maintain the site.