### PR TITLE
[PageGuard] -> [Others]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1463,6 +1463,7 @@ Available for MacOS, Linux, & Windows<br>
 | [Material Design Resources](https://material.io/resources)| Use Material tools, downloads, and interactive projects to simplify your workflow. |
 | [Nodesign.dev](https://nodesign.dev) | A collection of tools for developers who have little to no artistic talent|
 | [A11ygator](https://a11ygator.chialab.io/)| A web tool to scan websites against WCAG rules |
+| [PageGuard](https://pageguard.org)| Free website health scanner — checks accessibility (WCAG 2.1), SEO, performance, and best practices. No login required. |
 | [Commitizen](http://commitizen.github.io/cz-cli/)| Command line tool to formatted commit messages according to the standards |
 | [CleanCss](https://www.cleancss.com/)| Tool For Code Formatter, Minifier, File Converter |
 | [Tiny helpers](https://tiny-helpers.dev/)| A collection of free single-purpose online tools for web developers |


### PR DESCRIPTION
Adding **PageGuard** to the Others section.

**Link:** https://pageguard.org

PageGuard is a free website health scanner that checks accessibility (WCAG 2.1 / ADA compliance), SEO, performance, and best practices — no login required for basic scans. Returns a score (0–100) across all four dimensions.

It fits alongside A11ygator and similar web developer tools in the Others section.