### PR TITLE
Add 'Related Repos' to Others section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1452,6 +1452,7 @@ Available for MacOS, Linux, & Windows<br>
 
 | Website&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | Description                                                       |
 | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [Related Repos](https://relatedrepos.com/) | Discover related open source projects. Find alternatives and other similar repositories. Updated daily. |
 | [Figpeek](https://figpeek.vercel.app/) | Figpeek is a new Figma and GitHub thumbnail generator. |
 | [Image Extractor](https://extract.pics/) | Online tool for extracting all images and SVGs of a website, all you is just to drop the URL |
 | [Vertopal](https://www.vertopal.com/) | Free online platform for converting computer files to a variety of file formats |


### PR DESCRIPTION
Added a new entry for 'Related Repos' to showcase a resource for discovering related open source projects.

# Add 'Related Repos' to Others section

Link: [https://relatedrepos.com/](https://relatedrepos.com/)

[Related Repos](https://relatedrepos.com/) helps developers to discover open source projects that are related to each other. This can be useful to find alternative or complementary packages when building a full application. Or you can simply surf around in different neighborhoods to find new ideas that you might not have been aware of.

Data and results are updated daily so you can keep coming back to discover fresh repositories. Results can be thought of as "users who expressed interest in this repository also expressed interest in these other repositories".


#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.
