### PR TITLE
Add WPSkins to HTML & CSS Templates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -592,7 +592,7 @@ Available for MacOS, Linux, & Windows<br>
 | [Horizon UI](https://horizon-ui.com/) | Trendiest open source Admin Template for React |
 | [KeenThemes](https://keenthemes.com/) | Free and Pro Html/Css3, Bootstrap5, Vue, React, Laravel templates |
 | [ScrewFast](https://github.com/mearashadowfax/ScrewFast) | Open-source Astro website template with sleek, customizable TailwindCSS components |
-
+| [WPSkins.org](https://wpskins.org) - Free directory of 2,800+ website themes across WordPress, Shopify, Webflow, Framer, Ghost, Astro, and more.
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>
 </div>


### PR DESCRIPTION
Hey Brad! Adding WPSkins.org to the HTML & CSS Templates section.

- Free directory of 2,800+ website themes
- Covers WordPress, Shopify, Webflow, Framer, Ghost, Hugo, Astro, and 8 more platforms
- No signups, no email walls, all sourced from official channels
- Active and growing

Thanks for maintaining this awesome resource!