### PR TITLE
Add IconKing – free Lottie previewer, color editor & .json↔.lottie converter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -836,6 +836,7 @@ Available for MacOS, Linux, & Windows<br>
 | [tailblocks](https://mertjf.github.io/tailblocks/)| Open source ready-to-use Tailwind CSS components. |
 | [Fast](https://www.fast.design/)| An interface system that can be used with modern Web Frameworks such as React, Vue and Angular. |
 | [LottieFiles ](https://lottiefiles.com/)| Interactive animations in many formats like json,gif and mp4, libraries and plugins for Web & Mobile . |
+| [IconKing](https://iconking.net) | Free browser-based Lottie animation previewer, color editor, and .json ↔ .lottie format converter. No account needed. |
 | [Kutty](https://kutty.netlify.app/)| A set of accessible and reusable prebuilt Tailwind components that are commonly used in web applications. |
 | [Tailwind Templates](https://tailwindtemplates.io/)| A free collection of Tailwindcss Templates - tailwind components for rapid UI development. |
 | [Stitches](https://stitches.hyperyolo.com/)| An HTML template generator using functional css. |


### PR DESCRIPTION
**[IconKing](https://iconking.net)** is a free, browser-based tool for working with Lottie animations:

- **Preview** any `.json` or `.lottie` file before adding it to your project
- **Edit colors** directly in the browser — no After Effects needed
- **Convert** between `.json` and `.lottie` formats (dotLottie is ~75% smaller)
- 100% client-side, no account or signup required

Adding it next to LottieFiles in the UI Components section since it complements the existing entry — LottieFiles is the library/marketplace, IconKing is the preview/editing/conversion tool you use before integrating files into code.