### PR TITLE
[Python Cheat Sheet – CheatGrid] -> [Others]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1514,7 +1514,7 @@ Available for MacOS, Linux, & Windows<br>
 | [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) | Test and optimize page load speed |
 | [Code Beautify](https://codebeautify.org/) | Free Online Tools like Code Beautifiers, Code Formatters, Editors, Viewers, Minifier, Validators, Converters for Developers|
 | [Vue CheatSheet](https://vue-cheatsheet.themeselection.com/) | An interactive cheatsheet of Vue, Vue Router, and Pinia. The only Vue CheatSheet you will ever need. |
-| [Python Cheat Sheet – CheatGrid](https://www.cheatgrid.com/programming-languages/0004-python-cheat-sheet) | Free Python quick-reference covering syntax, data structures, functions, OOP, and more. CheatGrid offers many developer cheat sheets across web development, DevOps, databases, AI and beyond. |
+| [Python Cheat Sheet – CheatGrid](https://www.cheatgrid.com/programming-languages/0004-python-cheat-sheet) | Free Python quick-reference covering syntax, data structures, functions, OOP, and more. CheatGrid contains many developer cheat sheets across web development, DevOps, databases, AI and beyond. |
 | [appydev](https://appydev.co/) | A collection of awesome tools, resources and products for people who create and live on the internet. |
 | [ExtendsClass](https://extendsclass.com/) | Free online tools for developers, including image compressors/encoders, code formatters, code playgrounds, and many other handy utilities. |
 | [RunJS](https://runjs.app/play) | Free online JavaScript playground.  |

--- a/readme.md
+++ b/readme.md
@@ -1514,7 +1514,7 @@ Available for MacOS, Linux, & Windows<br>
 | [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) | Test and optimize page load speed |
 | [Code Beautify](https://codebeautify.org/) | Free Online Tools like Code Beautifiers, Code Formatters, Editors, Viewers, Minifier, Validators, Converters for Developers|
 | [Vue CheatSheet](https://vue-cheatsheet.themeselection.com/) | An interactive cheatsheet of Vue, Vue Router, and Pinia. The only Vue CheatSheet you will ever need. |
-| [Python Cheat Sheet – CheatGrid](https://www.cheatgrid.com/programming-languages/0004-python-cheat-sheet) | Free Python quick-reference covering syntax, data structures, functions, OOP, and more. CheatGrid offers 900+ developer cheat sheets across web development, DevOps, databases, and beyond. |
+| [Python Cheat Sheet – CheatGrid](https://www.cheatgrid.com/programming-languages/0004-python-cheat-sheet) | Free Python quick-reference covering syntax, data structures, functions, OOP, and more. CheatGrid offers many developer cheat sheets across web development, DevOps, databases, AI and beyond. |
 | [appydev](https://appydev.co/) | A collection of awesome tools, resources and products for people who create and live on the internet. |
 | [ExtendsClass](https://extendsclass.com/) | Free online tools for developers, including image compressors/encoders, code formatters, code playgrounds, and many other handy utilities. |
 | [RunJS](https://runjs.app/play) | Free online JavaScript playground.  |

--- a/readme.md
+++ b/readme.md
@@ -1514,6 +1514,7 @@ Available for MacOS, Linux, & Windows<br>
 | [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) | Test and optimize page load speed |
 | [Code Beautify](https://codebeautify.org/) | Free Online Tools like Code Beautifiers, Code Formatters, Editors, Viewers, Minifier, Validators, Converters for Developers|
 | [Vue CheatSheet](https://vue-cheatsheet.themeselection.com/) | An interactive cheatsheet of Vue, Vue Router, and Pinia. The only Vue CheatSheet you will ever need. |
+| [Python Cheat Sheet – CheatGrid](https://www.cheatgrid.com/programming-languages/0004-python-cheat-sheet) | Free Python quick-reference covering syntax, data structures, functions, OOP, and more. CheatGrid offers 900+ developer cheat sheets across web development, DevOps, databases, and beyond. |
 | [appydev](https://appydev.co/) | A collection of awesome tools, resources and products for people who create and live on the internet. |
 | [ExtendsClass](https://extendsclass.com/) | Free online tools for developers, including image compressors/encoders, code formatters, code playgrounds, and many other handy utilities. |
 | [RunJS](https://runjs.app/play) | Free online JavaScript playground.  |


### PR DESCRIPTION
# Add Python Cheat Sheet to Others

Adding CheatGrid's free Python cheat sheet to the Others section, alongside existing cheat sheet resources like Devhints.io, OverAPI, Bootstrap CheatSheet, and Vue CheatSheet.

Link: https://www.cheatgrid.com/programming-languages/0004-python-cheat-sheet

#### Checklist:

- [x] I have performed a self-review of submitted resource and its follows the guidelines of the project.