### PR TITLE
Add DigicamFilter under Online Design Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1150,6 +1150,7 @@ Available for MacOS, Linux, & Windows<br>
 
 | Website&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | Description |
 | ----------------------- | ------------------ |
+| [DigicamFilter](https://digicamfilter.online/)| Free in-browser tool that gives photos a retro digital-camera look (CCD, disposable, Y2K, film grain); no signup, nothing uploaded |
 | [Figma](https://www.figma.com/graphic-design-tool/)| Online graphic design tool (Free & paid options) |
 | [Penpot](https://penpot.app/)| Penpot is the first Open Source design and prototyping platform meant for cross-domain teams. Non dependent on operating systems, Penpot is web based and works with open web standards (SVG). For all and empowered by the community [Open Source and selfhostable](https://github.com/penpot/penpot#what-is-penpot) |
 | [Vectr](https://vectr.com/)| Free vector graphics software|


### PR DESCRIPTION
Link: https://digicamfilter.online/

Added DigicamFilter under **Online Design Tools** (the section explicitly covers "photo editors"). It's a free, in-browser tool that applies retro digital-camera looks (CCD, disposable, Y2K, film grain) to your photos. No signup, and nothing is uploaded.

#### Checklist:

- [x] I have performed a self-review of submitted resource and it follows the guidelines of the project.