### PR TITLE
[okaybabe gradient pack] -> [Colors]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -243,6 +243,7 @@ Available for MacOS, Linux, & Windows<br>
 | [AiSeka](https://www.aiseka.com/) | Discover Created the best Color Palette & Color Tools. |
 | [Volume](https://www.volumecolor.io/) | 3D OKLCH color palette generator. |
 | [EnigmaEasel](https://enigmaeasel.com) | AI color palette generator and gradient generator for creating accessible design systems with built-in contrast auditing and Tailwind exports. |
+| [okaybabe gradient pack](https://okaybabe.com/gradients) | 41 free CSS gradients in OKLCH with Tailwind v4, SCSS, JSON and Figma exports (MIT) |
 
 <div align="right">
     <b><a href="#table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
Adds the okaybabe gradient pack (41 free, MIT-licensed CSS gradients in OKLCH; Tailwind v4, SCSS, JSON and Figma exports) to the Colors section.

Link: https://okaybabe.com/gradients

#### Checklist:

- [x] I have performed a self-review of the submitted resource and it follows the guidelines of the project.