### PR TITLE
Add UI Beats to React UI libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -951,6 +951,7 @@ Available for MacOS, Linux, & Windows<br>
 | [Tremor](https://tremor.so/) | React components to build charts and dashboards with |
 | [Aceternity UI](https://ui.aceternity.com/)| Copy paste the most trending components and use them in your websites without having to worry about styling and animations. |
 | [Magic UI](https://magicui.design/)| free and open-source animated components built with React, Typescript, Tailwind CSS, and Framer Motion. |
+| [UI Beats](https://uibeats.com/)| Animated React components built with TypeScript, Tailwind CSS and Motion. Copy, paste, or install with the shadcn CLI. |
 | [Code UI](https://www.codeui.co.in/)| Beautifully designied mobile responsive components built with HTML, CSS , JS and React, Typescript, Tailwind CSS, and Framer Motion. 100% open-source, and customizable. |
 | [Edil Ozi](https://www.edil-ozi.pro/)| Component Library for Developers. Open Source components you can copy and paste to your apps. |
 | [Shadcn Templates](https://shadcntemplates.com/)| Free collection of Shadcn UI templates, components, blocks, boilerplates, and more. |


### PR DESCRIPTION
Adds [UI Beats](https://uibeats.com/) to the React UI libraries table, alongside the other copy-paste animation libraries already listed there (Aceternity UI, Magic UI).

UI Beats is a free, MIT-licensed registry of animated React components built with TypeScript, Tailwind CSS and Motion. Components install with the shadcn CLI, so the source lands in your project rather than behind a package API.

- Site: https://uibeats.com
- Repo: https://github.com/nikhils4/ui-beats

Single-row addition, no other changes to the file.
